### PR TITLE
Observations on GSA URI

### DIFF
--- a/csp-wtf/README.md
+++ b/csp-wtf/README.md
@@ -60,7 +60,7 @@ __Answer:__ Any idea?????
 ```
 __WTF:___ ```gsa://onpageload```
 
-__Answer:__ Might be related to Google Search Appliance. (to confirm?)
+__Answer:__ Appears related to Google Search App on iOS.
 
 ---------------------------------------
 


### PR DESCRIPTION
I've seen these too. Based on correlation with Apache logs [1], I think GSA = Google Search App. See also [2] and [3].

[1] Example user agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) GSA/18.0.130791545 Mobile/13G35 Safari/600.1.4"
[2] http://superuser.com/questions/739863/ipad-user-agent-changes-depending-on-location-work-home
[3] https://productforums.google.com/forum/#!topic/gmail/0fv1zc8xyO0