### PR TITLE
Added Clouflare AMP service

### DIFF
--- a/csp-for-third-party-services/README.md
+++ b/csp-for-third-party-services/README.md
@@ -135,4 +135,11 @@ connect-src embedr.flickr.com geo.query.yahoo.com ;
 script-src assets.codepen.io production-assets.codepen.io ;
 ```
 
+## Cloudflare AMP service
+
+    style-src: https://amp.cloudflare.com 
+    script-src: https://amp.cloudflare.com 
+    connect-src: https://discovery.amp.cloudflare.com/v1/ampUrls:batchGet
+
+
 Feel free to participate. :)


### PR DESCRIPTION
After confirmation with CF AMP team, this is the list of needed rules
to allow CF-powered AMP pages on your site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nico3333fr/csp-useful/23)
<!-- Reviewable:end -->
