### PR TITLE
Adding a resource to the reporting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ JS/jQuery plugins should provide the CSP requirements they need to work (especia
 - https://github.com/rtanglao/rt-csp
 - [CSP implementations are broken](https://jellyhive.com/activity/posts/2018/03/26/csp-implementations-are-broken/)
 - [CSP report for Netlify](https://github.com/stefanjudis/stefan-judis-website/blob/020f1b005cb1fcf4da8afa4407d9514917aecda0/functions/report.js)
+- [Run SQL on violation JSON, send violations to Slack](https://pipedream.com/@dylburger/process-csp-violations-p_brC8vJ/readme)
 
 
 ### Why you should use CSP


### PR DESCRIPTION
Pipedream is a free service that lets you run Node code and run basic actions (think: Zapier) in response to HTTP requests. Anyone can copy and run this workflow and point their report-uri to their workflow's HTTP endpoint. Then, they can run SQL on violation data, e.g. to understand what the most common violations / blocked URIs are:

SELECT effective_directive, blocked_uri, COUNT(*)
FROM csp_violation_data
GROUP BY 1, 2
ORDER BY 3 DESC;

They can also send violations to Slack (the workflow shows an example of how to filter out specific violations to reduce noise).

Thought this might provide a cool example of how to run code on response violations!